### PR TITLE
Force <body> contents to be of an even width.

### DIFF
--- a/museum_site/static/css/main.css
+++ b/museum_site/static/css/main.css
@@ -13,6 +13,7 @@
     margin-right: auto;
     justify-items:center;
     justify-content:space-around;
+    width:round(100%, 2px);
 }
 
 .grid-root[data-active-tool=true] { margin-top:70px; }


### PR DESCRIPTION
At odd widths, the contents of the content column are rendered centered, so at an offset of one half-pixel. This caused font rendering within in-article ZZT scrolls to be blurry.